### PR TITLE
Add support for hiding ItemFlags

### DIFF
--- a/src/main/java/me/badbones69/crazycrates/api/CrazyCrates.java
+++ b/src/main/java/me/badbones69/crazycrates/api/CrazyCrates.java
@@ -856,6 +856,7 @@ public class CrazyCrates {
 			.setLore(file.getStringList(path + "Lore"))
 			.setGlowing(file.getBoolean(path + "Glowing"))
 			.setUnbreakable(file.getBoolean(path + "Unbreakable"))
+			.hideItemFlags(file.getBoolean(path + "HideItemFlags"))
 			.setPlayer(file.getString(path + "Player"));
 			HashMap<Enchantment, Integer> enchants = new HashMap<>();
 			if(file.contains(path + "DisplayEnchantments")) {

--- a/src/main/java/me/badbones69/crazycrates/api/objects/ItemBuilder.java
+++ b/src/main/java/me/badbones69/crazycrates/api/objects/ItemBuilder.java
@@ -4,6 +4,7 @@ import me.badbones69.crazycrates.multisupport.itemnbtapi.NBTItem;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
+import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
@@ -30,6 +31,7 @@ public class ItemBuilder {
 	private String player;
 	private HashMap<Enchantment, Integer> enchantments;
 	private Boolean unbreakable;
+	private Boolean hideItemFlags;
 	private Boolean glowing;
 	private ItemStack referenceItem;
 	private HashMap<String, String> namePlaceholders;
@@ -47,6 +49,7 @@ public class ItemBuilder {
 		this.player = "";
 		this.enchantments = new HashMap<>();
 		this.unbreakable = false;
+		this.hideItemFlags = false;
 		this.glowing = false;
 		this.namePlaceholders = new HashMap<>();
 		this.lorePlaceholders = new HashMap<>();
@@ -357,16 +360,34 @@ public class ItemBuilder {
 	public Boolean isUnbreakable() {
 		return unbreakable;
 	}
-	
-	/**
-	 * Set if the item in the builder to be unbreakable or not.
-	 * @param unbreakable True will set it to be unbreakable and false will make it able to take damage.
-	 * @return The ItemBuilder with updated info.
-	 */
-	public ItemBuilder setUnbreakable(Boolean unbreakable) {
-		this.unbreakable = unbreakable;
-		return this;
-	}
+    
+    /**
+     * Set if the item in the builder to be unbreakable or not.
+     * @param unbreakable True will set it to be unbreakable and false will make it able to take damage.
+     * @return The ItemBuilder with updated info.
+     */
+    public ItemBuilder setUnbreakable(Boolean unbreakable) {
+        this.unbreakable = unbreakable;
+        return this;
+    }
+    
+    /**
+     * Set if the item should hide item flags or not
+     * @param hideItemFlags true the item will hide item flags. false will show them.
+     * @return The ItemBuilder with updated info.
+     */
+    public ItemBuilder hideItemFlags(Boolean hideItemFlags) {
+        this.hideItemFlags = hideItemFlags;
+        return this;
+    }
+    
+    /**
+     * Check if the item in the builder has hidden item flags.
+     * @return The ItemBuilder with updated info.
+     */
+    public Boolean areItemFlagsHidden() {
+        return hideItemFlags;
+    }
 	
 	/**
 	 * Check if the item in the builder is glowing.
@@ -397,6 +418,7 @@ public class ItemBuilder {
 		itemMeta.setLore(getUpdatedLore());
 		itemMeta.setUnbreakable(unbreakable);
 		item.setItemMeta(itemMeta);
+		hideFlags(item, hideItemFlags);
 		item.addUnsafeEnchantments(enchantments);
 		addGlow(item, glowing);
 		NBTItem nbt = new NBTItem(item);
@@ -420,6 +442,18 @@ public class ItemBuilder {
 	
 	private String color(String msg) {
 		return ChatColor.translateAlternateColorCodes('&', msg);
+	}
+	
+	private ItemStack hideFlags(ItemStack item, Boolean toggle) {
+	    if (toggle) {
+	        if(item != null && item.hasItemMeta()) {
+	            ItemMeta itemMeta = item.getItemMeta();
+	            itemMeta.addItemFlags(ItemFlag.values());
+	            item.setItemMeta(itemMeta);
+	            return item;
+	        }
+        }
+	    return item;
 	}
 	
 	private ItemStack addGlow(ItemStack item, boolean toggle) {


### PR DESCRIPTION
This allows to hide all flags. For example armor and unbreakable
Before: http://prntscr.com/nlsjvw

After: http://prntscr.com/nlsk60

Tested on 1.13.2
Configs without the option set, resulting in no Flags hidden