### PR TITLE
Reformat comments in example crates + added missing nodes

### DIFF
--- a/src/main/resources/Crates/Basic.yml
+++ b/src/main/resources/Crates/Basic.yml
@@ -1,75 +1,81 @@
 Crate:
-  CrateType: CSGO #Type of crate (CSGO/QuadCrate/QuickCrate/Roulette/CrateOnTheGo/FireCracker/Wonder/Wheel/War/Cosmic(This requires a additional info to work.)).
-  CrateName: '&8Basic Crate' #Name of the Inventory if a GUI crate.
-  Preview-Name: '&8Basic Crate Preview' #The name of the inventory that will be in the preview GUI.
-  StartingKeys: 0 #Starting amount of keys when the player 1st joins.
-  InGUI: true #If the crate shows in the /cc GUI. (If the crate type is QuickCrate/CrateOnTheGo/FireCracker then the Crate will not work. Quick Crate requires a Physical Crate.)
-  Slot: 21 #Slot the item is in the GUI.
-  OpeningBroadCast: true #Enables/Disables the Broadcasts message when they open a crate.
-  BroadCast: '%Prefix%&6&l%Player% &7is opening a &7&lBasic Chest&7.' #Message that is broadcast when opening the crate.
-  Item: 'CHEST' #Item the crate is in the GUI
-  Glowing: false #If the crate in the main /cc GUI is glowing or not.
-  Name: '&7&lBasic Chest' #Name of the item in the GUI.
-  Lore: #The lore of the item in the GUI.
+  #Type of crate (CSGO/QuadCrate/QuickCrate/Roulette/CrateOnTheGo/FireCracker/Wonder/Wheel/War/Cosmic(This requires a additional info to work.)).
+  CrateType: CSGO
+  #Name of the Inventory if a GUI crate.
+  CrateName: '&8Basic Crate'
+  #The name of the inventory that will be in the preview GUI.
+  Preview-Name: '&8Basic Crate Preview'
+  #Starting amount of keys when the player 1st joins.
+  StartingKeys: 0
+  #If the crate shows in the /cc GUI. (If the crate type is QuickCrate/CrateOnTheGo/FireCracker then the Crate will not work. Quick Crate requires a Physical Crate.)
+  InGUI: true
+  #Slot the item is in the GUI.
+  Slot: 21
+  #Enables/Disables the Broadcasts message when they open a crate.
+  OpeningBroadCast: true
+  #Message that is broadcast when opening the crate.
+  BroadCast: '%Prefix%&6&l%Player% &7is opening a &7&lBasic Chest&7.'
+  #Item the crate is in the GUI
+  Item: 'CHEST'
+  #If the crate in the main /cc GUI is glowing or not.
+  Glowing: false
+  #Name of the item in the GUI.
+  Name: '&7&lBasic Chest'
+  #The lore of the item in the GUI.
+  Lore:
     - '&7This crate contains strange objects.'
     - '&7You have &6%Keys% keys &7to open this crate with.'
     - '&7&l(&e&l!&7&l) Right click to view rewards.'
   PhysicalKey:
-    Name: '&7&lBasic Crate &b&lKey' #Name of the Key.
+    #Name of the Key.
+    Name: '&7&lBasic Crate &b&lKey'
+    #Lore of the Key.
     Lore:
       - '&7A special Key' #Lore of the Key.
       - '&7For a special Crate.'
-    Item: 'TRIPWIRE_HOOK' #The item the key is.
-    Glowing: True #Makes the key look enchanted.
-#         For Cosmic Crates Only
-#############################################
-#  Tiers: #The tiers in the Crate
-#    Basic: #The Config Name for the Crate
-#      Name: '&8Basic Prize' #The in-game name of the Crate
-#      Color: 7 #Use the MetaData for the color of the glass
-#      Chance: 80 #Chance of that item getting picked. It would be 80/100 chance because MaxRange is 100.
-#      MaxRange: 100 #The max range that the chance will go though.
-#    UnCommon:
-#      Name: '&aUnCommon Prize'
-#      Color: 5
-#      Chance: 55
-#      MaxRange: 100
-#    Rare:
-#      Name: '&4Rare Prize'
-#      Color: 14
-#      Chance: 20
-#      MaxRange: 100
-#############################################
-  Prizes: #All the prizes that can be gotten in the Crate.
+    #The item the key is.
+    Item: 'TRIPWIRE_HOOK'
+    #Makes the key look enchanted.
+    Glowing: True
+  #All the prizes that can be gotten in the Crate.
+  Prizes:
     1:
-      DisplayName: '&7&lBasic Grass' #Name of the item shown by the crate.
-      DisplayItem: 'GRASS_BLOCK' #Item that is shown by the crate.
-      DisplayAmount: 1 #The amount that is displayed.
-      Lore: #Lore will be shown in rewards GUI.
+      #Name of the item shown by the crate.
+      DisplayName: '&7&lBasic Grass'
+      #Item that is shown by the crate.
+      DisplayItem: 'GRASS_BLOCK'
+      #The amount that is displayed.
+      DisplayAmount: 1
+      #Lore will be shown in rewards GUI.
+      Lore:
         - '&7Win some grass for your fields.'
         - '&6&lChance: &c&l40%'
-      MaxRange: 100 #The max range that the chance will go though.
-      Chance: 40 #Chance of that item getting picked. It would be 40/100 chance because MaxRange is 100.
-      Firework: false #Firework when it is won.
-      Glowing: false #Toggle if the item has a glowing effect but doesn't have an enchantment on it.
-      Player: '' #Set the item to 397:3 and then add the players name for this to take effect.
-      Unbreakable: false #Adds the unbreaking NBT tag to the display item to allow it to have custom textures.
-#        For Cosmic Crates Only
-#############################################
-#       Tiers: #The Tiers the rewards can be found in.
-#         - 'Basic'
-#         - 'UnCommon'
-#         - 'Rare'
-#############################################
-# Items that the player wins if this prize is picked. (If you wish not to give an Item in the prize just delete the Items Section)
-#             Items: Options
-# Item:<ID:MD> - You can choose the item with its id and meta data.
-# Amount:<Number> - Choose how many of the item you get.
-# Name:<Name> - The display name that goes on the item.
-# Lore:<Line 1>,<Line 2>,<Line 3>,<Line 4> - The lore that will go under the enchantments. Split lines with a ','
-# Unbreakable-Item:<True/False> - Will add the Unbreaking NBT tag to the item to allow custom textured items to be gained through the envoys.
-# <Enchantment>:<Level> - Choose the enchantment you want to add to the item. You can use the in-game names of the enchantment if you want. Replace the spaces in the name with "_".
-###################################
+      #Adds enchantments to the display item.
+      DisplayEnchantments:
+        - 'PROTECTION_ENVIRONMENTAL:1'
+        - 'OXYGEN:1'
+      #The max range that the chance will go though.
+      MaxRange: 100
+      #Chance of that item getting picked. It would be 40/100 chance because MaxRange is 100.
+      Chance: 40
+      #Firework when it is won.
+      Firework: false
+      #Toggle if the item has a glowing effect but doesn't have an enchantment on it.
+      Glowing: false
+      #Set the item to 397:3 and then add the players name for this to take effect.
+      Player: ''
+      #Adds the unbreaking NBT tag to the display item to allow it to have custom textures.
+      Unbreakable: false
+      #When set to true, tags like Armor, Unbreakable and other tags are hidden and not visible to the user.
+      HideItemFlags: false
+      # Items that the player wins if this prize is picked. (If you wish not to give an Item in the prize just delete the Items Section) 
+      # Items: Options
+      # Item:<ID:MD> - You can choose the item with its id and meta data.
+      # Amount:<Number> - Choose how many of the item you get.
+      # Name:<Name> - The display name that goes on the item.
+      # Lore:<Line 1>,<Line 2>,<Line 3>,<Line 4> - The lore that will go under the enchantments. Split lines with a ','
+      # Unbreakable-Item:<True/False> - Will add the Unbreaking NBT tag to the item to allow custom textured items to be gained through the envoys.
+      # <Enchantment>:<Level> - Choose the enchantment you want to add to the item. You can use the in-game names of the enchantment if you want. Replace the spaces in the name with "_".
       Items:
         - 'Item:GRASS_BLOCK, Amount:32, Name:&7&lBasic Grass'
       #Commands are the commands that are run when this prize is won. (If you wish not to use a CMD in the prize just delete the Commands Section)
@@ -80,9 +86,12 @@ Crate:
       #If you do not wish to have players get messaged that they won this prize then just remove the Messages: option.
       Messages:
         - '&7You just won a &7&lBasic Grass&7.'
-      BlackListed-Permissions: [] #This allows for one time winnable prizes. If a player has one of the permissions then they will not be able to win it.
-      Alternative-Prize: #This allows users who have won the same prize before to get alternative prizes. They must of a BlackListed-Permission to get a alternative prize.
-        Toggle: false #Toggle if the prize will use alternative prizes for the blacklisted permission.
+      #This allows for one time winnable prizes. If a player has one of the permissions then they will not be able to win it.
+      BlackListed-Permissions: []
+      #This allows users who have won the same prize before to get alternative prizes. They must of a BlackListed-Permission to get a alternative prize.
+      Alternative-Prize:
+        #Toggle if the prize will use alternative prizes for the blacklisted permission.
+        Toggle: false
         Messages: []
         Commands: []
         Items: []
@@ -93,17 +102,18 @@ Crate:
       Lore:
         - '&7Win a cheap helmet.'
         - '&6&lChance: &c&l60%'
-      DisplayEnchantments: #Adds enchantments to the display item.
-        - 'PROTECTION_ENVIRONMENTAL:1'
-        - 'OXYGEN:1'
+      DisplayEnchantments: []
       MaxRange: 100
       Chance: 60
       Firework: false
       Glowing: false
       Player: ''
       Unbreakable: false
+      HideItemFlags: false
       Items:
         - 'Item:GOLDEN_HELMET, Amount:1, Name:&bCheap Helmet, PROTECTION_ENVIRONMENTAL:1, OXYGEN:1'
+      Commands: []
+      Messages: []
       BlackListed-Permissions: []
       Alternative-Prize:
         Toggle: false
@@ -123,6 +133,8 @@ Crate:
       Glowing: false
       Player: ''
       Unbreakable: false
+      HideItemFlags: false
+      Items: []
       Commands:
         - 'eco give %Player% 1000'
       # - 'pex user %player% add crazycrates.blacklist.basic.3' #This is the line where you would give the user the permission.

--- a/src/main/resources/Crates/Classic.yml
+++ b/src/main/resources/Crates/Classic.yml
@@ -35,10 +35,15 @@ Crate:
       Chance: 40
       Firework: false
       Glowing: false
+      Player: ''
+      Unbreakable: false
+      HideItemFlags: false
       Items:
         - 'Item:CHAINMAIL_LEGGINGS, Amount:1, Name:&aFancy Pants, PROTECTION_ENVIRONMENTAL:2'
+      Commands: []
       Messages:
         - '&7You just won a &a&lFancy Pantst&7.'
+      BlackListed-Permissions: []
       Alternative-Prize:
         Toggle: false
         Messages: []
@@ -58,10 +63,15 @@ Crate:
       Chance: 35
       Firework: false
       Glowing: false
+      Player: ''
+      Unbreakable: false
+      HideItemFlags: false
       Items:
         - 'Item:DIAMOND_SWORD, Amount:1, Name:&bClassic Sword, DAMAGE_ALL:2, FIRE_ASPECT:1'
+      Commands: []
       Messages:
         - '&7You just won a &b&lClassic Sword&7.'
+      BlackListed-Permissions: []
       Alternative-Prize:
         Toggle: false
         Messages: []
@@ -78,10 +88,16 @@ Crate:
       Chance: 20
       Firework: true
       Glowing: false
+      Player: ''
+      Unbreakable: false
+      HideItemFlags: false
+      Items: []
       Commands:
         - 'Eco give %Player% 100000'
+      Commands: []
       Messages:
         - '&7You just won &a$100,000&7.'
+      BlackListed-Permissions: []
       Alternative-Prize:
         Toggle: false
         Messages: []

--- a/src/main/resources/Crates/Crazy.yml
+++ b/src/main/resources/Crates/Crazy.yml
@@ -32,12 +32,18 @@ Crate:
       DisplayEnchantments:
         - 'PROTECTION_ENVIRONMENTAL:5'
         - 'DURABILITY:3'
+      Messages: []
       MaxRange: 100
       Chance: 40
       Firework: false
       Glowing: false
+      Player: ''
+      Unbreakable: false
+      HideItemFlags: false
       Items:
         - 'Item:DIAMOND_CHESTPLATE, Amount:1, Name:&3Rare ChestPlate, PROTECTION_ENVIRONMENTAL:5, DURABILITY:3'
+      Commands: []
+      BlackListed-Permissions: []
       Alternative-Prize:
         Toggle: false
         Messages: []
@@ -57,10 +63,15 @@ Crate:
       Chance: 35
       Firework: false
       Glowing: false
+      Player: ''
+      Unbreakable: false
+      HideItemFlags: false
       Items:
         - 'Item:GOLDEN_SWORD, Amount:1, Name:&b&lCrazy &4&lSword, DAMAGE_ALL:5, FIRE_ASPECT:1'
+      Commands: []
       Messages:
         - '&7You just won a &b&lCrazy &4&lSword&7.'
+      BlackListed-Permissions: []
       Alternative-Prize:
         Toggle: false
         Messages: []
@@ -77,10 +88,15 @@ Crate:
       Chance: 20
       Firework: true
       Glowing: false
+      Player: ''
+      Unbreakable: false
+      HideItemFlags: false
+      Items: []
       Commands:
         - 'Eco give %Player% 1000000'
       Messages:
         - '&7You just won &a$1,000,000&7.'
+      BlackListed-Permissions: []
       Alternative-Prize:
         Toggle: false
         Messages: []

--- a/src/main/resources/Crates/Galactic.yml
+++ b/src/main/resources/Crates/Galactic.yml
@@ -1,33 +1,40 @@
 Crate:
-  CrateType: Cosmic #Type of crate.
-  CrateName: '&8Galactic Crate' #Name of the Inventory if a GUI crate.
+  CrateType: Cosmic
+  CrateName: '&8Galactic Crate'
   Preview-Name: '&8Galactic Crate Preview'
-  StartingKeys: 0 #Starting amount of keys when the player 1st joins.
-  InGUI: true #If the crate shows in the /cc GUI.
-  Slot: 23 #Slot the item is in the GUI.
-  OpeningBroadCast: false #Enables/Disables the Broadcasts message when they open a crate.
-  BroadCast: '' #Message that is broadcast when opening the crate.
-  Item: 'ENDER_CHEST' #Item the crate is in the GUI
-  Glowing: false #If the crate in the main /cc GUI is glowing or not.
-  Name: '&d&lGalactic Chest' #Name of the item in the GUI.
-  Lore: #The lore of the item in the GUI.
+  StartingKeys: 0
+  InGUI: true
+  Slot: 23
+  OpeningBroadCast: false
+  BroadCast: ''
+  Item: 'ENDER_CHEST'
+  Glowing: false
+  Name: '&d&lGalactic Chest'
+  Lore:
     - '&7This crate contains strange objects,'
     - '&7from somewhere beyond this planet.'
     - '&7You have &6%Keys% keys &7to open this crate with.'
     - '&7&l(&e&l!&7&l) Right click to view rewards.'
   PhysicalKey:
-    Name: '&d&lGalactic Crate &b&lKey' #Name of the Key.
+    Name: '&d&lGalactic Crate &b&lKey'
     Lore:
-      - '&7A special Key' #Lore of the Key.
+      - '&7A special Key'
       - '&7For a special Crate.'
-    Item: 'TRIPWIRE_HOOK' #The item the key is.
+    Item: 'TRIPWIRE_HOOK'
     Glowing: true
-  Tiers: #The tiers in the Crate
-    Basic: #The Config Name for the Crate
-      Name: '&8Basic Prize' #The in-game name of the Crate
-      Color: 'GRAY_STAINED_GLASS_PANE' #Use the MetaData for the color of the glass
-      Chance: 80 #Chance of that item getting picked. It would be 80/100 chance because MaxRange is 100.
-      MaxRange: 100 #The max range that the chance will go though.
+  # Tiers are available in Cosmic crates only
+  #The tiers in the Crate
+  Tiers:
+    #The Config Name for the Crate
+    Basic:
+      #The in-game name of the Crate
+      Name: '&8Basic Prize'
+      #Use the MetaData for the color of the glass
+      Color: 'GRAY_STAINED_GLASS_PANE'
+      #Chance of that item getting picked. It would be 80/100 chance because MaxRange is 100.
+      Chance: 80
+      #The max range that the chance will go though.
+      MaxRange: 100
     UnCommon:
       Name: '&aUnCommon Prize'
       Color: 'LIME_STAINED_GLASS_PANE'
@@ -38,34 +45,33 @@ Crate:
       Color: 'RED_STAINED_GLASS_PANE'
       Chance: 20
       MaxRange: 100
-  Prizes: #All the prizes that can be gotten in the Crate.
+  Prizes:
     1:
-      DisplayName: '&d&lGalactic Grass' #Name of the item shown by the crate.
-      DisplayItem: 'GRASS_BLOCK' #Item that is shown by the crate.
-      DisplayAmount: 1 #The ammount that is displayed
-      Lore: #Lore will be shown in rewards GUI.
+      DisplayName: '&d&lGalactic Grass'
+      DisplayItem: 'GRASS_BLOCK'
+      DisplayAmount: 1
+      Lore:
         - '&7Win some grass for your fields.'
         - '&6&lChance: &c&l40%'
-      MaxRange: 100 #The max range that the chance will go though.
-      Chance: 40 #Chance of that item getting picked. It would be 40/100 chance because MaxRange is 100.
-      Firework: false #Firework when it is won.
+      MaxRange: 100
+      Chance: 40
+      Firework: false
       Glowing: false
-      Tiers: #The Tiers the rewards can be found in.
+      Player: ''
+      Unbreakable: false
+      HideItemFlags: false
+      # Tiers are available in Cosmic crates only
+      #The Tiers the rewards can be found in.
+      Tiers:
         - 'Basic'
         - 'UnCommon'
         - 'Rare'
-      #Items that the player wins if this prize is picked. (If you wish not to give an Item in the prize just delete the Items Section)
-      #Please use these to make the item.
-      #Item: to decide the kind of item it is.
-      #Amount: the amount of that item they get.
-      #Name: a custom name for that item (ColorCode dose work).
-      #Lore: a custom lore for the item (ColorCode does work) and to make a new line in the lore use a , to split the lines.
       Items:
         - 'Item:GRASS_BLOCK, Amount:32, Name:&d&lGalactic Grass'
-      #Commands are the commands that are run when this prize is won. (If you wish not to use a CMD in the prize just delete the Commands Section)
-      #You can use %Player% to get the player that won the prize.
       Commands:
         - 'broadcast &6&l%Player% &7has just won some Basic Grass.'
+      Messages: []
+      BlackListed-Permissions: []
       Alternative-Prize:
         Toggle: false
         Messages: []
@@ -85,12 +91,18 @@ Crate:
       Chance: 60
       Firework: false
       Glowing: false
+      Player: ''
+      Unbreakable: false
+      HideItemFlags: false
       Tiers:
         - 'Basic'
         - 'UnCommon'
         - 'Rare'
       Items:
         - 'Item:GOLDEN_HELMET, Amount:1, Name:&bCheap Helmet, PROTECTION_ENVIRONMENTAL:1, OXYGEN:1'
+      Commands: []
+      Messages: []
+      BlackListed-Permissions: []
       Alternative-Prize:
         Toggle: false
         Messages: []
@@ -107,12 +119,18 @@ Crate:
       Chance: 20
       Firework: true
       Glowing: false
+      Player: ''
+      Unbreakable: false
+      HideItemFlags: false
       Tiers:
         - 'Basic'
         - 'UnCommon'
         - 'Rare'
+      Items: []
       Commands:
         - 'eco give %Player% 1000'
+      Messages: []
+      BlackListed-Permissions: []
       Alternative-Prize:
         Toggle: false
         Messages: []
@@ -132,10 +150,16 @@ Crate:
       Chance: 10
       Firework: false
       Glowing: false
+      Player: ''
+      Unbreakable: false
+      HideItemFlags: false
       Tiers:
         - 'Rare'
       Items:
         - 'Item:GOLDEN_SWORD, Amount:1, Name:&b&lCrazy &4&lSword, DAMAGE_ALL:5, FIRE_ASPECT:1'
+      Commands: []
+      Messages: []
+      BlackListed-Permissions: []
       Alternative-Prize:
         Toggle: false
         Messages: []
@@ -152,10 +176,16 @@ Crate:
       Chance: 20
       Firework: true
       Glowing: false
+      Player: ''
+      Unbreakable: false
+      HideItemFlags: false
       Tiers:
         - 'Rare'
+      Items: []
       Commands:
         - 'Eco give %Player% 1000000'
+      Messages: []
+      BlackListed-Permissions: []
       Alternative-Prize:
         Toggle: false
         Messages: []
@@ -173,11 +203,17 @@ Crate:
       Chance: 10
       Firework: true
       Glowing: true
+      Player: ''
+      Unbreakable: false
+      HideItemFlags: false
       Tiers:
         - 'UnCommon'
         - 'Rare'
+      Items: []
       Commands:
         - 'cc give physical crazy 2 %Player%'
+      Messages: []
+      BlackListed-Permissions: []
       Alternative-Prize:
         Toggle: false
         Messages: []


### PR DESCRIPTION
Moved all comments to basic and only left cosmic specific comments in cosmic
The old config lines right behind the values made them kinda hard to see/read (At least in some editors, for example Notepad++)
Added remaining nodes to all configs. Missing nodes confused me as I copy pasted
some sections and was wondering about missing nodes.
I am aware that you can remove nodes if you wish, but most people are copy pasting or start editing existing configs and might wondering about not seeing some of them. Or they don't even know they exist.
Thats purely a design thing and you might think different about it, so no worries if you don't agree