### PR TITLE
Let users customize the preview lines per crate config

### DIFF
--- a/plugin/src/main/java/me/badbones69/crazycrates/api/CrazyCrates.java
+++ b/plugin/src/main/java/me/badbones69/crazycrates/api/CrazyCrates.java
@@ -632,7 +632,7 @@ public class CrazyCrates {
 	public Inventory loadPreview(Crate crate) {
 		FileConfiguration file = crate.getFile();
 		int slots = 9;
-		for(int size = file.getConfigurationSection("Crate.Prizes").getKeys(false).size(); size > 9 && slots < 54; size -= 9) {
+		for(int size = file.getConfigurationSection("Crate.Prizes").getKeys(false).size(); size > 9 && slots < crate.getMaxSlots(); size -= 9) {
 			slots += 9;
 		}
 		Inventory inv = Bukkit.createInventory(null, slots, Methods.color(file.getString("Crate.Name")));

--- a/plugin/src/main/java/me/badbones69/crazycrates/api/objects/Crate.java
+++ b/plugin/src/main/java/me/badbones69/crazycrates/api/objects/Crate.java
@@ -67,23 +67,23 @@ public class Crate {
 	}
 	
 	public void setPreviewChestlines(int amount) {
-	    int finalAmount;
-	    if (amount < 3) {
-            finalAmount = 3;
-        } else if (amount > 6) {
-            finalAmount = 6;
-        } else {
-            finalAmount = amount;
-        }
-	    this.previewChestlines = finalAmount;
+		int finalAmount;
+		if(amount < 3) {
+			finalAmount = 3;
+		}else if(amount > 6) {
+			finalAmount = 6;
+		}else {
+			finalAmount = amount;
+		}
+		this.previewChestlines = finalAmount;
 	}
 	
 	public int getPreviewChestLines() {
-	    return this.previewChestlines;
+		return this.previewChestlines;
 	}
 	
 	public int getMaxSlots() {
-	    return this.previewChestlines * 9;
+		return this.previewChestlines * 9;
 	}
 	
 	/**
@@ -459,21 +459,21 @@ public class Crate {
 	}
 	
 	public int getAbsoluteItemPosition(int baseSlot) {
-	    return baseSlot + (previewChestlines - 1) * 9;
+		return baseSlot + (previewChestlines - 1) * 9;
 	}
 	
 	private void setDefaultItems(Inventory inv, Player player) {
 		if(boarderToggle) {
-		    List<Integer> borderItems = Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8);
+			List<Integer> borderItems = Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8);
 			for(int i : borderItems) {//Top Boarder slots
 				inv.setItem(i, boarderItem.build());
 			}
-			for (int i = 0; i < borderItems.size(); i++) {
-	            borderItems.set(i, getAbsoluteItemPosition(borderItems.get(i)));
-	        }
-	        for(int i : borderItems) {//Bottom Boarder slots
-	            inv.setItem(i, boarderItem.build());
-	        }
+			for(int i = 0; i < borderItems.size(); i++) {
+				borderItems.set(i, getAbsoluteItemPosition(borderItems.get(i)));
+			}
+			for(int i : borderItems) {//Bottom Boarder slots
+				inv.setItem(i, boarderItem.build());
+			}
 		}
 		int page = Preview.getPage(player);
 		if(Preview.playerInMenu(player)) {

--- a/plugin/src/main/java/me/badbones69/crazycrates/api/objects/Crate.java
+++ b/plugin/src/main/java/me/badbones69/crazycrates/api/objects/Crate.java
@@ -61,7 +61,7 @@ public class Crate {
 		this.previewName = Methods.color(previewName);
 		this.newPlayerKeys = newPlayerKeys;
 		this.giveNewPlayerKeys = newPlayerKeys > 0;
-		for(int amount = preview.size(); amount > getMaxSlots() - 18; amount -= getMaxSlots() - 9, maxPage++) ;
+		for(int amount = preview.size(); amount > getMaxSlots() - (boarderToggle ? 18 : 9); amount -= getMaxSlots() - (boarderToggle ? 18 : 9), maxPage++) ;
 		this.crateInventoryName = file != null ? Methods.color(file.getString("Crate.CrateName")) : "";
 		this.boarderItem = file != null && file.contains("Crate.Preview.Glass.Item") ? new ItemBuilder().setMaterial(file.getString("Crate.Preview.Glass.Item")).setName(" ") : new ItemBuilder().setMaterial(Material.AIR);
 	}

--- a/plugin/src/main/java/me/badbones69/crazycrates/api/objects/Crate.java
+++ b/plugin/src/main/java/me/badbones69/crazycrates/api/objects/Crate.java
@@ -32,6 +32,7 @@ public class Crate {
 	private ArrayList<Prize> prizes;
 	private String crateInventoryName;
 	private Boolean giveNewPlayerKeys;
+	private int previewChestlines;
 	private Integer newPlayerKeys;
 	private ArrayList<ItemStack> preview;
 	private ArrayList<Tier> tiers;
@@ -54,14 +55,35 @@ public class Crate {
 		this.prizes = prizes;
 		this.crateType = crateType;
 		this.preview = loadPreview();
+		setPreviewChestlines(file != null ? file.getInt("Crate.Preview.ChestLines", 6) : 6);
 		this.previewToggle = file != null && (!file.contains("Crate.Preview.Toggle") || file.getBoolean("Crate.Preview.Toggle"));
 		this.boarderToggle = file != null && file.getBoolean("Crate.Preview.Glass.Toggle");
 		this.previewName = Methods.color(previewName);
 		this.newPlayerKeys = newPlayerKeys;
 		this.giveNewPlayerKeys = newPlayerKeys > 0;
-		for(int amount = preview.size(); amount > 36; amount -= 45, maxPage++) ;
+		for(int amount = preview.size(); amount > getMaxSlots() - 18; amount -= getMaxSlots() - 9, maxPage++) ;
 		this.crateInventoryName = file != null ? Methods.color(file.getString("Crate.CrateName")) : "";
 		this.boarderItem = file != null && file.contains("Crate.Preview.Glass.Item") ? new ItemBuilder().setMaterial(file.getString("Crate.Preview.Glass.Item")).setName(" ") : new ItemBuilder().setMaterial(Material.AIR);
+	}
+	
+	public void setPreviewChestlines(int amount) {
+	    int finalAmount;
+	    if (amount < 3) {
+            finalAmount = 3;
+        } else if (amount > 6) {
+            finalAmount = 6;
+        } else {
+            finalAmount = amount;
+        }
+	    this.previewChestlines = finalAmount;
+	}
+	
+	public int getPreviewChestLines() {
+	    return this.previewChestlines;
+	}
+	
+	public int getMaxSlots() {
+	    return this.previewChestlines * 9;
 	}
 	
 	/**
@@ -243,7 +265,7 @@ public class Crate {
 	 * @return The preview as an Inventory object.
 	 */
 	public Inventory getPreview(Player player) {
-		Inventory inv = Bukkit.createInventory(null, 54, previewName);
+		Inventory inv = Bukkit.createInventory(null, getMaxSlots(), previewName);
 		setDefaultItems(inv, player);
 		for(ItemStack item : getPageItems(Preview.getPage(player))) {
 			int nextSlot = inv.firstEmpty();
@@ -261,7 +283,7 @@ public class Crate {
 	 * @return The preview as an Inventory object.
 	 */
 	public Inventory getPreview(Player player, int page) {
-		Inventory inv = Bukkit.createInventory(null, 54, previewName);
+		Inventory inv = Bukkit.createInventory(null, getMaxSlots(), previewName);
 		setDefaultItems(inv, player);
 		for(ItemStack item : getPageItems(page)) {
 			int nextSlot = inv.firstEmpty();
@@ -419,13 +441,13 @@ public class Crate {
 		List<ItemStack> list = preview;
 		List<ItemStack> items = new ArrayList<>();
 		if(page <= 0) page = 1;
-		int max = 36;
+		int max = boarderToggle ? getMaxSlots() - 18 : getMaxSlots() - 9;
 		int index = page * max - max;
 		int endIndex = index >= list.size() ? list.size() - 1 : index + max;
 		for(; index < endIndex; index++) {
 			if(index < list.size()) items.add(list.get(index));
 		}
-		for(; items.size() == 0; page--) {
+		for(; items.isEmpty(); page--) {
 			if(page <= 0) break;
 			index = page * max - max;
 			endIndex = index >= list.size() ? list.size() - 1 : index + max;
@@ -436,37 +458,44 @@ public class Crate {
 		return items;
 	}
 	
+	public int getAbsoluteItemPosition(int baseSlot) {
+	    return baseSlot + (previewChestlines - 1) * 9;
+	}
+	
 	private void setDefaultItems(Inventory inv, Player player) {
 		if(boarderToggle) {
-			for(int i : Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8)) {//Top Boarder slots
+		    List<Integer> borderItems = Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8);
+			for(int i : borderItems) {//Top Boarder slots
 				inv.setItem(i, boarderItem.build());
 			}
-		}
-		for(int i : Arrays.asList(45, 46, 47, 49, 51, 52, 53)) {//Bottom Boarder slots
-			inv.setItem(i, boarderItem.build());
+			for (int i = 0; i < borderItems.size(); i++) {
+	            borderItems.set(i, getAbsoluteItemPosition(borderItems.get(i)));
+	        }
+	        for(int i : borderItems) {//Bottom Boarder slots
+	            inv.setItem(i, boarderItem.build());
+	        }
 		}
 		int page = Preview.getPage(player);
-		int maxPage = getMaxPage();
 		if(Preview.playerInMenu(player)) {
-			inv.setItem(49, Preview.getMenuButton());
+			inv.setItem(getAbsoluteItemPosition(4), Preview.getMenuButton());
 		}
 		if(page == 1) {
-			inv.setItem(48, new ItemBuilder()
+			inv.setItem(getAbsoluteItemPosition(3), new ItemBuilder()
 			.setMaterial(cc.useNewMaterial() ? "GRAY_STAINED_GLASS_PANE" : "STAINED_GLASS_PANE")
 			.setDamage(cc.useNewMaterial() ? 0 : 7)
 			.setName(" ")
 			.build());
 		}else {
-			inv.setItem(48, Preview.getBackButton(player));
+			inv.setItem(getAbsoluteItemPosition(3), Preview.getBackButton(player));
 		}
-		if(page == maxPage) {
-			inv.setItem(50, new ItemBuilder()
+		if(page == getMaxPage()) {
+			inv.setItem(getAbsoluteItemPosition(5), new ItemBuilder()
 			.setMaterial(cc.useNewMaterial() ? "GRAY_STAINED_GLASS_PANE" : "STAINED_GLASS_PANE")
 			.setDamage(cc.useNewMaterial() ? 0 : 7)
 			.setName(" ")
 			.build());
 		}else {
-			inv.setItem(50, Preview.getNextButton(player));
+			inv.setItem(getAbsoluteItemPosition(5), Preview.getNextButton(player));
 		}
 	}
 	

--- a/plugin/src/main/java/me/badbones69/crazycrates/controllers/Preview.java
+++ b/plugin/src/main/java/me/badbones69/crazycrates/controllers/Preview.java
@@ -34,16 +34,16 @@ public class Preview implements Listener {
 					e.setCancelled(true);
 					ItemStack item = e.getCurrentItem();
 					if(item != null) {
-						if(e.getRawSlot() == 49) {// Clicked the menu button.
+						if(e.getRawSlot() == crate.getAbsoluteItemPosition(4)) {// Clicked the menu button.
 							if(playerInMenu(player)) {
 								GUIMenu.openGUI(player);
 							}
-						}else if(e.getRawSlot() == 50) {// Clicked the next button.
+						}else if(e.getRawSlot() == crate.getAbsoluteItemPosition(5)) {// Clicked the next button.
 							if(getPage(player) < crate.getMaxPage()) {
 								nextPage(player);
 								openPreview(player, crate);
 							}
-						}else if(e.getRawSlot() == 48) {// Clicked the back button.
+						}else if(e.getRawSlot() == crate.getAbsoluteItemPosition(3)) {// Clicked the back button.
 							if(getPage(player) > 1 && getPage(player) <= crate.getMaxPage()) {
 								backPage(player);
 								openPreview(player, crate);

--- a/plugin/src/main/resources/Crates1.12.2-Down/Basic.yml
+++ b/plugin/src/main/resources/Crates1.12.2-Down/Basic.yml
@@ -29,6 +29,8 @@ Crate:
   Preview:
     #Turn on and off the preview for this crate.
     Toggle: true
+    #How many lines the previewChest should have. Including Header and Bottom (Between 3 and 6)
+    ChestLines: 6
     Glass:
       #Turn the glass boarder in the preview on and off.
       Toggle: true

--- a/plugin/src/main/resources/Crates1.12.2-Down/Classic.yml
+++ b/plugin/src/main/resources/Crates1.12.2-Down/Classic.yml
@@ -16,6 +16,7 @@ Crate:
     - '&7&l(&e&l!&7&l) Right click to view rewards.'
   Preview:
     Toggle: true
+    ChestLines: 6
     Glass:
       Toggle: true
       Item: 'STAINED_GLASS_PANE:4'

--- a/plugin/src/main/resources/Crates1.12.2-Down/Crazy.yml
+++ b/plugin/src/main/resources/Crates1.12.2-Down/Crazy.yml
@@ -16,6 +16,7 @@ Crate:
     - '&7&l(&e&l!&7&l) Right click to view rewards.'
   Preview:
     Toggle: true
+    ChestLines: 6
     Glass:
       Toggle: true
       Item: 'STAINED_GLASS_PANE:15'

--- a/plugin/src/main/resources/Crates1.12.2-Down/Galactic.yml
+++ b/plugin/src/main/resources/Crates1.12.2-Down/Galactic.yml
@@ -17,6 +17,7 @@ Crate:
     - '&7&l(&e&l!&7&l) Right click to view rewards.'
   Preview:
     Toggle: true
+    ChestLines: 6
     Glass:
       Toggle: true
       Item: 'STAINED_GLASS_PANE:10'

--- a/plugin/src/main/resources/Crates1.13-Up/Basic.yml
+++ b/plugin/src/main/resources/Crates1.13-Up/Basic.yml
@@ -29,6 +29,8 @@ Crate:
   Preview:
     #Turn on and off the preview for this crate.
     Toggle: true
+    #How many lines the previewChest should have. Including Header and Bottom (Between 3 and 6)
+    ChestLines: 6
     Glass:
       #Turn the glass boarder in the preview on and off.
       Toggle: true

--- a/plugin/src/main/resources/Crates1.13-Up/Classic.yml
+++ b/plugin/src/main/resources/Crates1.13-Up/Classic.yml
@@ -16,6 +16,7 @@ Crate:
     - '&7&l(&e&l!&7&l) Right click to view rewards.'
   Preview:
     Toggle: true
+    ChestLines: 6
     Glass:
       Toggle: true
       Item: 'YELLOW_STAINED_GLASS_PANE'

--- a/plugin/src/main/resources/Crates1.13-Up/Crazy.yml
+++ b/plugin/src/main/resources/Crates1.13-Up/Crazy.yml
@@ -16,6 +16,7 @@ Crate:
     - '&7&l(&e&l!&7&l) Right click to view rewards.'
   Preview:
     Toggle: true
+    ChestLines: 6
     Glass:
       Toggle: true
       Item: 'BLACK_STAINED_GLASS_PANE'

--- a/plugin/src/main/resources/Crates1.13-Up/Galactic.yml
+++ b/plugin/src/main/resources/Crates1.13-Up/Galactic.yml
@@ -17,6 +17,7 @@ Crate:
     - '&7&l(&e&l!&7&l) Right click to view rewards.'
   Preview:
     Toggle: true
+    ChestLines: 6
     Glass:
       Toggle: true
       Item: 'PURPLE_STAINED_GLASS_PANE'


### PR DESCRIPTION
Defaults to 6 lines (double chest)
Can be 3 to 6 lines including the header/bottom
Fixes long standing issue that when disabling the glass border one line was empty
Disabling the glass border now also disables the bottom border