### PR TITLE
Add getItemInMainHand Method to NMS Class

### DIFF
--- a/api/src/main/java/me/badbones69/crazycrates/multisupport/nms/NMSSupport.java
+++ b/api/src/main/java/me/badbones69/crazycrates/multisupport/nms/NMSSupport.java
@@ -3,6 +3,8 @@ package me.badbones69.crazycrates.multisupport.nms;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 
 import java.io.File;
 import java.util.List;
@@ -18,5 +20,7 @@ public interface NMSSupport {
 	List<Location> getLocations(File file, Location loc);
 	
 	List<Material> getQuadCrateBlacklistBlocks();
+
+	ItemStack getItemInMainHand(Player player);
 	
 }

--- a/api/src/main/java/me/badbones69/crazycrates/multisupport/nms/NMSSupport.java
+++ b/api/src/main/java/me/badbones69/crazycrates/multisupport/nms/NMSSupport.java
@@ -20,7 +20,7 @@ public interface NMSSupport {
 	List<Location> getLocations(File file, Location loc);
 	
 	List<Material> getQuadCrateBlacklistBlocks();
-
+	
 	ItemStack getItemInMainHand(Player player);
 	
 }

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -143,6 +143,10 @@
                     <groupId>org.bstats</groupId>
                     <artifactId>bstats-bukkit</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>io.papermc</groupId>
+                    <artifactId>paperlib</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
     </dependencies>

--- a/plugin/src/main/java/me/badbones69/crazycrates/Main.java
+++ b/plugin/src/main/java/me/badbones69/crazycrates/Main.java
@@ -285,7 +285,7 @@ public class Main extends JavaPlugin implements Listener {
 					if(sender instanceof Player) if(!Methods.permCheck(sender, "admin")) return true;
 					Player player = (Player) sender;
 					if(args.length >= 3) {
-						ItemStack item = player.getInventory().getItemInMainHand();
+						ItemStack item = cc.getNMSSupport().getItemInMainHand(player);
 						if(item != null && item.getType() != Material.AIR) {
 							Crate crate = cc.getCrateFromName(args[1]);
 							if(crate != null) {

--- a/plugin/src/main/java/me/badbones69/crazycrates/Methods.java
+++ b/plugin/src/main/java/me/badbones69/crazycrates/Methods.java
@@ -5,7 +5,6 @@ import me.badbones69.crazycrates.api.enums.Messages;
 import me.badbones69.crazycrates.api.objects.ItemBuilder;
 import me.badbones69.crazycrates.controllers.FileManager.Files;
 import me.badbones69.crazycrates.controllers.FireworkDamageAPI;
-import me.badbones69.crazycrates.multisupport.Version;
 import org.bukkit.*;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -31,6 +30,7 @@ public class Methods {
 	private static CrazyCrates cc = CrazyCrates.getInstance();
 	public static HashMap<Player, String> path = new HashMap<>();
 	public static Plugin plugin = Bukkit.getServer().getPluginManager().getPlugin("CrazyCrates");
+	private static Random random = new Random(); 
 	
 	public static String color(String msg) {
 		return ChatColor.translateAlternateColorCodes('&', msg);
@@ -38,14 +38,6 @@ public class Methods {
 	
 	public static String removeColor(String msg) {
 		return ChatColor.stripColor(msg);
-	}
-	
-	public static ItemStack getItemInHand(Player player) {
-		if(Version.getCurrentVersion().isNewer(Version.v1_8_R3)) {
-			return player.getInventory().getItemInMainHand();
-		}else {
-			return player.getItemInHand();
-		}
 	}
 	
 	public static HashMap<ItemStack, String> getItems(Player player) {
@@ -61,10 +53,9 @@ public class Methods {
 			}
 			try {
 				ItemStack item = new ItemBuilder().setMaterial(id).setName(name).build();
-				Random number = new Random();
 				int num;
 				for(int counter = 1; counter <= 1; counter++) {
-					num = 1 + number.nextInt(max);
+					num = 1 + random.nextInt(max);
 					if(num >= 1 && num <= chance) items.put(item, "Crate.Prizes." + reward);
 				}
 			}catch(Exception e) {
@@ -205,12 +196,11 @@ public class Methods {
 	}
 	
 	public static Integer randomNumber(int min, int max) {
-		Random i = new Random();
-		return min + i.nextInt(max - min);
+		return min + random.nextInt(max - min);
 	}
 	
 	public static boolean isSimilar(Player player, ItemStack two) {
-		return isSimilar(getItemInHand(player), two);
+		return isSimilar(cc.getNMSSupport().getItemInMainHand(player), two);
 	}
 	
 	public static boolean isSimilar(ItemStack one, ItemStack two) {
@@ -354,7 +344,7 @@ public class Methods {
 		newMaterial ? "GREEN_STAINED_GLASS_PANE" : "STAINED_GLASS_PANE:13",// 13
 		newMaterial ? "RED_STAINED_GLASS_PANE" : "STAINED_GLASS_PANE:14",// 14
 		newMaterial ? "BLACK_STAINED_GLASS_PANE" : "STAINED_GLASS_PANE:15");// 15
-		return new ItemBuilder().setMaterial(colors.get(new Random().nextInt(colors.size())));
+		return new ItemBuilder().setMaterial(colors.get(random.nextInt(colors.size())));
 	}
 	
 }

--- a/plugin/src/main/java/me/badbones69/crazycrates/Methods.java
+++ b/plugin/src/main/java/me/badbones69/crazycrates/Methods.java
@@ -30,7 +30,7 @@ public class Methods {
 	private static CrazyCrates cc = CrazyCrates.getInstance();
 	public static HashMap<Player, String> path = new HashMap<>();
 	public static Plugin plugin = Bukkit.getServer().getPluginManager().getPlugin("CrazyCrates");
-	private static Random random = new Random(); 
+	private static Random random = new Random();
 	
 	public static String color(String msg) {
 		return ChatColor.translateAlternateColorCodes('&', msg);

--- a/plugin/src/main/java/me/badbones69/crazycrates/cratetypes/CrateOnTheGo.java
+++ b/plugin/src/main/java/me/badbones69/crazycrates/cratetypes/CrateOnTheGo.java
@@ -22,7 +22,7 @@ public class CrateOnTheGo implements Listener {
 	public void onCrateOpen(PlayerInteractEvent e) {
 		Player player = e.getPlayer();
 		if(e.getAction() == Action.RIGHT_CLICK_BLOCK) {
-			ItemStack item = Methods.getItemInHand(player);
+			ItemStack item = cc.getNMSSupport().getItemInMainHand(player);
 			if(item != null) {
 				for(Crate crate : cc.getCrates()) {
 					if(crate.getCrateType() == CrateType.CRATE_ON_THE_GO) {

--- a/v1_10_R1/src/main/java/me/badbones69/crazycrates/multisupport/nms/v1_10_R1/NMS_v1_10_R1.java
+++ b/v1_10_R1/src/main/java/me/badbones69/crazycrates/multisupport/nms/v1_10_R1/NMS_v1_10_R1.java
@@ -104,10 +104,10 @@ public class NMS_v1_10_R1 implements NMSSupport {
 		blockList.add(Material.WOOD_BUTTON);
 		return blockList;
 	}
-
-    @Override
-    public ItemStack getItemInMainHand(Player player) {
-        return player.getInventory().getItemInMainHand();
-    }
+	
+	@Override
+	public ItemStack getItemInMainHand(Player player) {
+		return player.getInventory().getItemInMainHand();
+	}
 	
 }

--- a/v1_10_R1/src/main/java/me/badbones69/crazycrates/multisupport/nms/v1_10_R1/NMS_v1_10_R1.java
+++ b/v1_10_R1/src/main/java/me/badbones69/crazycrates/multisupport/nms/v1_10_R1/NMS_v1_10_R1.java
@@ -6,6 +6,8 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.craftbukkit.v1_10_R1.CraftWorld;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -102,5 +104,10 @@ public class NMS_v1_10_R1 implements NMSSupport {
 		blockList.add(Material.WOOD_BUTTON);
 		return blockList;
 	}
+
+    @Override
+    public ItemStack getItemInMainHand(Player player) {
+        return player.getInventory().getItemInMainHand();
+    }
 	
 }

--- a/v1_11_R1/src/main/java/me/badbones69/crazycrates/multisupport/nms/v1_11_R1/NMS_v1_11_R1.java
+++ b/v1_11_R1/src/main/java/me/badbones69/crazycrates/multisupport/nms/v1_11_R1/NMS_v1_11_R1.java
@@ -106,8 +106,8 @@ public class NMS_v1_11_R1 implements NMSSupport {
 	}
 	
 	@Override
-    public ItemStack getItemInMainHand(Player player) {
-        return player.getInventory().getItemInMainHand();
-    }
+	public ItemStack getItemInMainHand(Player player) {
+		return player.getInventory().getItemInMainHand();
+	}
 	
 }

--- a/v1_11_R1/src/main/java/me/badbones69/crazycrates/multisupport/nms/v1_11_R1/NMS_v1_11_R1.java
+++ b/v1_11_R1/src/main/java/me/badbones69/crazycrates/multisupport/nms/v1_11_R1/NMS_v1_11_R1.java
@@ -6,6 +6,8 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.craftbukkit.v1_11_R1.CraftWorld;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -102,5 +104,10 @@ public class NMS_v1_11_R1 implements NMSSupport {
 		blockList.add(Material.WOOD_BUTTON);
 		return blockList;
 	}
+	
+	@Override
+    public ItemStack getItemInMainHand(Player player) {
+        return player.getInventory().getItemInMainHand();
+    }
 	
 }

--- a/v1_12_R1/src/main/java/me/badbones69/crazycrates/multisupport/nms/v1_12_R1/NMS_v1_12_R1.java
+++ b/v1_12_R1/src/main/java/me/badbones69/crazycrates/multisupport/nms/v1_12_R1/NMS_v1_12_R1.java
@@ -106,8 +106,8 @@ public class NMS_v1_12_R1 implements NMSSupport {
 	}
 	
 	@Override
-    public ItemStack getItemInMainHand(Player player) {
-        return player.getInventory().getItemInMainHand();
-    }
+	public ItemStack getItemInMainHand(Player player) {
+		return player.getInventory().getItemInMainHand();
+	}
 	
 }

--- a/v1_12_R1/src/main/java/me/badbones69/crazycrates/multisupport/nms/v1_12_R1/NMS_v1_12_R1.java
+++ b/v1_12_R1/src/main/java/me/badbones69/crazycrates/multisupport/nms/v1_12_R1/NMS_v1_12_R1.java
@@ -6,6 +6,8 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.craftbukkit.v1_12_R1.CraftWorld;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -102,5 +104,10 @@ public class NMS_v1_12_R1 implements NMSSupport {
 		blockList.add(Material.WOOD_BUTTON);
 		return blockList;
 	}
+	
+	@Override
+    public ItemStack getItemInMainHand(Player player) {
+        return player.getInventory().getItemInMainHand();
+    }
 	
 }

--- a/v1_13_R2/src/main/java/me/badbones69/crazycrates/multisupport/nms/v1_13_R2/NMS_v1_13_R2.java
+++ b/v1_13_R2/src/main/java/me/badbones69/crazycrates/multisupport/nms/v1_13_R2/NMS_v1_13_R2.java
@@ -9,6 +9,8 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.craftbukkit.v1_13_R2.CraftWorld;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 
 import java.io.File;
 import java.io.IOException;
@@ -82,5 +84,10 @@ public class NMS_v1_13_R2 implements NMSSupport {
 		blockList.add(Material.STONE_BUTTON);
 		return blockList;
 	}
+	
+	@Override
+    public ItemStack getItemInMainHand(Player player) {
+        return player.getInventory().getItemInMainHand();
+    }
 	
 }

--- a/v1_13_R2/src/main/java/me/badbones69/crazycrates/multisupport/nms/v1_13_R2/NMS_v1_13_R2.java
+++ b/v1_13_R2/src/main/java/me/badbones69/crazycrates/multisupport/nms/v1_13_R2/NMS_v1_13_R2.java
@@ -86,8 +86,8 @@ public class NMS_v1_13_R2 implements NMSSupport {
 	}
 	
 	@Override
-    public ItemStack getItemInMainHand(Player player) {
-        return player.getInventory().getItemInMainHand();
-    }
+	public ItemStack getItemInMainHand(Player player) {
+		return player.getInventory().getItemInMainHand();
+	}
 	
 }

--- a/v1_14_R1/src/main/java/me/badbones69/crazycrates/multisupport/nms/v1_14_R1/NMS_v1_14_R1.java
+++ b/v1_14_R1/src/main/java/me/badbones69/crazycrates/multisupport/nms/v1_14_R1/NMS_v1_14_R1.java
@@ -96,8 +96,8 @@ public class NMS_v1_14_R1 implements NMSSupport {
 	}
 	
 	@Override
-    public ItemStack getItemInMainHand(Player player) {
-        return player.getInventory().getItemInMainHand();
-    }
+	public ItemStack getItemInMainHand(Player player) {
+		return player.getInventory().getItemInMainHand();
+	}
 	
 }

--- a/v1_14_R1/src/main/java/me/badbones69/crazycrates/multisupport/nms/v1_14_R1/NMS_v1_14_R1.java
+++ b/v1_14_R1/src/main/java/me/badbones69/crazycrates/multisupport/nms/v1_14_R1/NMS_v1_14_R1.java
@@ -9,6 +9,8 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.craftbukkit.v1_14_R1.CraftWorld;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 
 import java.io.File;
 import java.io.IOException;
@@ -92,5 +94,10 @@ public class NMS_v1_14_R1 implements NMSSupport {
 		blockList.add(Material.STONE_BUTTON);
 		return blockList;
 	}
+	
+	@Override
+    public ItemStack getItemInMainHand(Player player) {
+        return player.getInventory().getItemInMainHand();
+    }
 	
 }

--- a/v1_8_R3/src/main/java/me/badbones69/crazycrates/multisupport/nms/v1_8_R3/NMS_v1_8_R3.java
+++ b/v1_8_R3/src/main/java/me/badbones69/crazycrates/multisupport/nms/v1_8_R3/NMS_v1_8_R3.java
@@ -106,8 +106,8 @@ public class NMS_v1_8_R3 implements NMSSupport {
 	}
 	
 	@Override
-    public ItemStack getItemInMainHand(Player player) {
-        return player.getItemInHand();
-    }
+	public ItemStack getItemInMainHand(Player player) {
+		return player.getItemInHand();
+	}
 	
 }

--- a/v1_8_R3/src/main/java/me/badbones69/crazycrates/multisupport/nms/v1_8_R3/NMS_v1_8_R3.java
+++ b/v1_8_R3/src/main/java/me/badbones69/crazycrates/multisupport/nms/v1_8_R3/NMS_v1_8_R3.java
@@ -6,6 +6,8 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.craftbukkit.v1_8_R3.CraftWorld;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -102,5 +104,10 @@ public class NMS_v1_8_R3 implements NMSSupport {
 		blockList.add(Material.WOOD_BUTTON);
 		return blockList;
 	}
+	
+	@Override
+    public ItemStack getItemInMainHand(Player player) {
+        return player.getItemInHand();
+    }
 	
 }

--- a/v1_9_R1/src/main/java/me/badbones69/crazycrates/multisupport/nms/v1_9_R1/NMS_v1_9_R1.java
+++ b/v1_9_R1/src/main/java/me/badbones69/crazycrates/multisupport/nms/v1_9_R1/NMS_v1_9_R1.java
@@ -6,6 +6,8 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.craftbukkit.v1_9_R1.CraftWorld;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -102,5 +104,10 @@ public class NMS_v1_9_R1 implements NMSSupport {
 		blockList.add(Material.WOOD_BUTTON);
 		return blockList;
 	}
+	
+	@Override
+    public ItemStack getItemInMainHand(Player player) {
+        return player.getInventory().getItemInMainHand();
+    }
 	
 }

--- a/v1_9_R1/src/main/java/me/badbones69/crazycrates/multisupport/nms/v1_9_R1/NMS_v1_9_R1.java
+++ b/v1_9_R1/src/main/java/me/badbones69/crazycrates/multisupport/nms/v1_9_R1/NMS_v1_9_R1.java
@@ -106,8 +106,8 @@ public class NMS_v1_9_R1 implements NMSSupport {
 	}
 	
 	@Override
-    public ItemStack getItemInMainHand(Player player) {
-        return player.getInventory().getItemInMainHand();
-    }
+	public ItemStack getItemInMainHand(Player player) {
+		return player.getInventory().getItemInMainHand();
+	}
 	
 }

--- a/v1_9_R2/src/main/java/me/badbones69/crazycrates/multisupport/nms/v1_9_R2/NMS_v1_9_R2.java
+++ b/v1_9_R2/src/main/java/me/badbones69/crazycrates/multisupport/nms/v1_9_R2/NMS_v1_9_R2.java
@@ -6,6 +6,8 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.craftbukkit.v1_9_R2.CraftWorld;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -102,5 +104,10 @@ public class NMS_v1_9_R2 implements NMSSupport {
 		blockList.add(Material.WOOD_BUTTON);
 		return blockList;
 	}
+	
+	@Override
+    public ItemStack getItemInMainHand(Player player) {
+        return player.getInventory().getItemInMainHand();
+    }
 	
 }

--- a/v1_9_R2/src/main/java/me/badbones69/crazycrates/multisupport/nms/v1_9_R2/NMS_v1_9_R2.java
+++ b/v1_9_R2/src/main/java/me/badbones69/crazycrates/multisupport/nms/v1_9_R2/NMS_v1_9_R2.java
@@ -106,8 +106,8 @@ public class NMS_v1_9_R2 implements NMSSupport {
 	}
 	
 	@Override
-    public ItemStack getItemInMainHand(Player player) {
-        return player.getInventory().getItemInMainHand();
-    }
+	public ItemStack getItemInMainHand(Player player) {
+		return player.getInventory().getItemInMainHand();
+	}
 	
 }


### PR DESCRIPTION
Fixes cc additem on 1.8.8
Removes dirty method of getItemInHand from Methods
Reuse Random. Only use new Random on class init if at all
Adds paperlib exclusion to WE dep