### PR TITLE
Make GUIMenu can add Unbreakable and HideItemFlags

### DIFF
--- a/plugin/src/main/java/me/badbones69/crazycrates/api/CrazyCrates.java
+++ b/plugin/src/main/java/me/badbones69/crazycrates/api/CrazyCrates.java
@@ -735,10 +735,8 @@ public class CrazyCrates {
             String player = file.getString("Crate.Prizes." + reward + ".Player", "");
             boolean glowing = file.getBoolean("Crate.Prizes." + reward + ".Glowing");
             int amount = file.getInt("Crate.Prizes." + reward + ".DisplayAmount", 1);
-            
             boolean unbreakable = file.getBoolean("Crate.Prizes." + reward + ".Unbreakable", false);
             boolean hideItemFlags = file.getBoolean("Crate.Prizes." + reward + ".HideItemsFlags", false);
-            
             for (String enchantmentName : file.getStringList("Crate.Prizes." + reward + ".DisplayEnchantments")) {
                 Enchantment enchantment = Methods.getEnchantment(enchantmentName.split(":")[0]);
                 if (enchantment != null) {

--- a/plugin/src/main/java/me/badbones69/crazycrates/api/CrazyCrates.java
+++ b/plugin/src/main/java/me/badbones69/crazycrates/api/CrazyCrates.java
@@ -735,6 +735,10 @@ public class CrazyCrates {
             String player = file.getString("Crate.Prizes." + reward + ".Player", "");
             boolean glowing = file.getBoolean("Crate.Prizes." + reward + ".Glowing");
             int amount = file.getInt("Crate.Prizes." + reward + ".DisplayAmount", 1);
+            
+            boolean unbreakable = file.getBoolean("Crate.Prizes." + reward + ".Unbreakable", false);
+            boolean hideItemFlags = file.getBoolean("Crate.Prizes." + reward + ".HideItemsFlags", false);
+            
             for (String enchantmentName : file.getStringList("Crate.Prizes." + reward + ".DisplayEnchantments")) {
                 Enchantment enchantment = Methods.getEnchantment(enchantmentName.split(":")[0]);
                 if (enchantment != null) {
@@ -742,7 +746,7 @@ public class CrazyCrates {
                 }
             }
             try {
-                inv.setItem(inv.firstEmpty(), new ItemBuilder().setMaterial(id).setAmount(amount).setName(name).setLore(lore).setEnchantments(enchantments).setGlowing(glowing).setPlayer(player).build());
+                inv.setItem(inv.firstEmpty(), new ItemBuilder().setMaterial(id).setAmount(amount).setName(name).setLore(lore).setUnbreakable(unbreakable).hideItemFlags(hideItemFlags).setEnchantments(enchantments).setGlowing(glowing).setPlayer(player).build());
             } catch (Exception e) {
                 inv.addItem(new ItemBuilder().setMaterial("RED_TERRACOTTA", "STAINED_CLAY:14").setName("&c&lERROR").setLore(Arrays.asList("&cThere is an error", "&cFor the reward: &c" + reward)).build());
             }

--- a/plugin/src/main/java/me/badbones69/crazycrates/controllers/GUIMenu.java
+++ b/plugin/src/main/java/me/badbones69/crazycrates/controllers/GUIMenu.java
@@ -85,6 +85,12 @@ public class GUIMenu implements Listener {
                     if (i.contains("Slot:")) {
                         slot = Integer.parseInt(i.replace("Slot:", ""));
                     }
+                    if(i.contains("Unbreakable-Item")) {
+                        item.setUnbreakable(Boolean.parseBoolean(i.replace("Unbreakable-Item:", "")));
+                    }
+                    if(i.contains("Hide-Item-Flags")) {
+                        item.hideItemFlags(Boolean.parseBoolean(i.replace("Hide-Item-Flags:", "")));
+                    }
                 }
                 if (slot > size) {
                     continue;

--- a/plugin/src/main/java/me/badbones69/crazycrates/controllers/GUIMenu.java
+++ b/plugin/src/main/java/me/badbones69/crazycrates/controllers/GUIMenu.java
@@ -46,50 +46,50 @@ public class GUIMenu implements Listener {
             for (String custom : Files.CONFIG.getFile().getStringList("Settings.GUI-Customizer")) {
                 int slot = 0;
                 ItemBuilder item = new ItemBuilder();
-                String[] b = custom.split(", ");
-                for (String i : b) {
-                    if (i.contains("Item:")) {
-                        item.setMaterial(i.replace("Item:", ""));
+                String[] split = custom.split(", ");
+                for (String option : split) {
+                    if (option.contains("Item:")) {
+                        item.setMaterial(option.replace("Item:", ""));
                     }
-                    if (i.contains("Name:")) {
-                        i = i.replace("Name:", "");
+                    if (option.contains("Name:")) {
+                        option = option.replace("Name:", "");
                         for (Crate crate : cc.getCrates()) {
                             if (crate.getCrateType() != CrateType.MENU) {
-                                i = i.replaceAll("%" + crate.getName().toLowerCase() + "%", cc.getVirtualKeys(player, crate) + "")
+                                option = option.replaceAll("%" + crate.getName().toLowerCase() + "%", cc.getVirtualKeys(player, crate) + "")
                                 .replaceAll("%" + crate.getName().toLowerCase() + "_physical%", cc.getPhysicalKeys(player, crate) + "")
                                 .replaceAll("%" + crate.getName().toLowerCase() + "_total%", cc.getTotalKeys(player, crate) + "");
                             }
                         }
-                        item.setName(i.replaceAll("%player%", player.getName()));
+                        item.setName(option.replaceAll("%player%", player.getName()));
                     }
-                    if (i.contains("Lore:")) {
-                        i = i.replace("Lore:", "");
-                        String[] d = i.split(",");
+                    if (option.contains("Lore:")) {
+                        option = option.replace("Lore:", "");
+                        String[] d = option.split(",");
                         for (String l : d) {
                             for (Crate crate : cc.getCrates()) {
                                 if (crate.getCrateType() != CrateType.MENU) {
-                                    i = i.replaceAll("%" + crate.getName().toLowerCase() + "%", cc.getVirtualKeys(player, crate) + "")
+                                    option = option.replaceAll("%" + crate.getName().toLowerCase() + "%", cc.getVirtualKeys(player, crate) + "")
                                     .replaceAll("%" + crate.getName().toLowerCase() + "_physical%", cc.getPhysicalKeys(player, crate) + "")
                                     .replaceAll("%" + crate.getName().toLowerCase() + "_total%", cc.getTotalKeys(player, crate) + "");
                                 }
                             }
-                            item.addLore(i.replaceAll("%player%", player.getName()));
+                            item.addLore(option.replaceAll("%player%", player.getName()));
                         }
                     }
-                    if (i.contains("Glowing:")) {
-                        item.setGlowing(Boolean.parseBoolean(i.replace("Glowing:", "")));
+                    if (option.contains("Glowing:")) {
+                        item.setGlowing(Boolean.parseBoolean(option.replace("Glowing:", "")));
                     }
-                    if (i.contains("Player:")) {
-                        item.setPlayer(i.replaceAll("%player%", player.getName()));
+                    if (option.contains("Player:")) {
+                        item.setPlayer(option.replaceAll("%player%", player.getName()));
                     }
-                    if (i.contains("Slot:")) {
-                        slot = Integer.parseInt(i.replace("Slot:", ""));
+                    if (option.contains("Slot:")) {
+                        slot = Integer.parseInt(option.replace("Slot:", ""));
                     }
-                    if(i.contains("Unbreakable-Item")) {
-                        item.setUnbreakable(Boolean.parseBoolean(i.replace("Unbreakable-Item:", "")));
+                    if (option.contains("Unbreakable-Item")) {
+                        item.setUnbreakable(Boolean.parseBoolean(option.replace("Unbreakable-Item:", "")));
                     }
-                    if(i.contains("Hide-Item-Flags")) {
-                        item.hideItemFlags(Boolean.parseBoolean(i.replace("Hide-Item-Flags:", "")));
+                    if (option.contains("Hide-Item-Flags")) {
+                        item.hideItemFlags(Boolean.parseBoolean(option.replace("Hide-Item-Flags:", "")));
                     }
                 }
                 if (slot > size) {


### PR DESCRIPTION
Pretty weird that you can use these properties in `crate config` but not in `GUI-Customizer` config.
I had tested and work pretty great, here is the config example:

```yaml
Slot:2, Item:DIAMOND_SWORD:4, Unbreakable-Item:true, Hide-Item-Flags:true, Name:&8
```