### PR TITLE
Update PlayerReceiveKeyEvent.java (Adding getHandlerList(), event doesnt work at all without it)

### DIFF
--- a/plugin/src/main/java/me/badbones69/crazycrates/api/events/PlayerReceiveKeyEvent.java
+++ b/plugin/src/main/java/me/badbones69/crazycrates/api/events/PlayerReceiveKeyEvent.java
@@ -48,6 +48,11 @@ public class PlayerReceiveKeyEvent extends Event implements Cancellable {
         return handlers;
     }
     
+    @Override
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+    
     public enum KeyReciveReason {
         /**
          * Received a key from the /cc give command.


### PR DESCRIPTION
Adding the getHandlerList() method fixes this error: http://prntscr.com/103t7ki